### PR TITLE
画面遷移させずにカテゴリー分けさせた。

### DIFF
--- a/app/assets/stylesheets/tops.scss
+++ b/app/assets/stylesheets/tops.scss
@@ -53,7 +53,9 @@ img.thumbnail {
     cursor: pointer;
     border: 3px solid white;
 }
-
+.item.behind{
+    display: none;
+}
 .item img.thumbnail.checked+.disabled_checkbox {
     /* 画像にcheckedクラスが指定されたときは、
 チェックボックスの非表示を解除します。 */

--- a/app/assets/stylesheets/tops.scss
+++ b/app/assets/stylesheets/tops.scss
@@ -1,9 +1,3 @@
-img.musubun {
-    margin: 0;
-    position: relative;
-    background-color:#fad352;
-}
-
 h1 {
     color: green;
 }
@@ -24,18 +18,6 @@ h1 {
     padding-top: 100%;
 }
 
-img {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    margin: auto;
-    object-fit: cover;
-}
-
 .disabled_checkbox {
     /* チェックボックスの位置は絶対位置にします。 */
     position: absolute;
@@ -48,6 +30,13 @@ img {
 }
 
 img.thumbnail {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    margin: auto;
+    object-fit: cover;
     width: 100%;
     height: 100%;
     cursor: pointer;
@@ -86,3 +75,49 @@ img.thumbnail {
     height: 10em;
     width: 250px;
 }
+
+.items {
+    margin-top: 152px;
+}
+
+ nav.navbar.is-hidden-desktop {
+    min-height: unset;
+    height: 150px !important;
+}
+
+ div.navbar-brand.is-hidden-desktop {
+    min-height: unset;
+    height: 150px !important;
+}
+
+ .navbar-item img {
+    max-height: unset !important;
+    height: 70px !important;
+}
+
+ .navbar-burger span {
+    left: 25px !important;
+    width: 100px !important;
+    height: 8px !important;
+}
+
+ .navbar-item.is-hidden-touch {
+    font-size: 40px !important;
+}
+
+ .navbar-item.is-hidden-desktop {
+    font-size: 60px !important;
+}
+
+ .navbar-burger span:nth-child(1) {
+    top: calc(50% - 27px) !important;
+}
+.navbar-burger span:nth-child(3) {
+    top: calc(50% + 26px) !important;
+}
+.navbar-burger.is-active span:nth-child(1) {
+    transform: translateY(30px) rotate(45deg) !important;
+}
+.navbar-burger.is-active span:nth-child(3) {
+    transform: translateY(-22px) rotate(-45deg) !important;
+} 

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -2,15 +2,59 @@
 <!-- jQuery読み込み -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 
+<nav class="navbar is-warning is-fixed-top is-hidden-touch" role="navigation" aria-label="main navigation">
+   <div class="navbar-brand is-hiddent-touch">
+     <a class="navbar-item" href="/">
+     <img src="musubun.png" class="musubun">
+     </a>
+   </div>
 
-<div>
-<img src="musubun.png" class="musubun">
-</div>
 
-<button class="button all  is-link is-outlined">ALL</button>
-<button class="button food is-success is-outlined">食べ物</button>
-<button class="button view is-danger is-outlined">景色</button>
+<div id="navbarBasicExample" class="navbar-menu">
+    <div class="navbar-start">
+      <a class="navbar-item all is-hidden-touch">
+        All
+      </a>
+      <a class="navbar-item view is-hidden-touch">
+        view
+      </a>
+      <a class="navbar-item food is-hidden-touch">
+        food
+      </a>
+    </div>
+  </div>
+</nav>
+<!-- /bulmaのnavbar -->
+<!-- bulmaのnavbar -->
+<nav class="navbar is-warning is-fixed-top is-hidden-desktop" role="navigation" aria-label="main navigation">
+  <div class="navbar-brand is-hidden-desktop">
+    <a class="navbar-item" href="/">
+    <img src="musubun.png" class="is-hidden-desktop musubun">
+    </a>
+    <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample" style="height: 150px; width: 150px">
+      <span aria-hidden="true"></span>
+      <span aria-hidden="true"></span>
+      <span aria-hidden="true"></span>
+    </a>
+  </div>
 
+  <div id="navbarBasicExample" class="navbar-menu">
+    <div class="navbar-start">
+      <a class="navbar-item all is-hidden-desktop">
+        All
+      </a>
+      <a class="navbar-item view is-hidden-desktop">
+        景色
+      </a>
+      <a class="navbar-item food is-hidden-desktop">
+        食べ物
+      </a>
+    </div>
+  </div>
+</nav>
+<!-- /bulmaのnavbar -->
+
+<div class="items">
 <%= form_with(url: map_path, local: true) do |f| %>
 <div class="container">
     <% @images.each do |image| %>
@@ -27,6 +71,7 @@
 </div>
 
 <% end %>
+</div>
 
 <script>
 $(document).on('turbolinks:load', function() {
@@ -47,7 +92,7 @@ $(document).on('turbolinks:load', function() {
     $(this).toggleClass("checked");//クラスにcheckedを追加
     var nextCheckbox = $(this).next();//クリックした画像についているチェックボックスだけを変数に入れた
     
-    if ($(nextCheckbox).prop('checked')) {　//その画像にチェックが入っていたら
+    if ($(nextCheckbox).prop('checked')) { //その画像にチェックが入っていたら
  
       // チェックを外す
       $(nextCheckbox).prop('checked', false);
@@ -71,20 +116,32 @@ $(document).on('turbolinks:load', function() {
 $(function() {
  
   // 食べ物ボタンをクリックしたら発動
-  $('.button.food').click(function() {
+  $('.navbar-item.food').click(function() {
     $(".item").removeClass('behind') //全部の画像からclass　behindを削除してから
     $("#view.item").addClass('behind');　//景色の写真だけにclass behindを追加
   });
 
   // 景色ボタンをクリックしたら発動
-  $('.button.view').click(function() {
+  $('.navbar-item.view').click(function() {
     $(".item").removeClass('behind')//全部の画像からclass　behindを削除してから
     $("#food.item").addClass('behind');//食べ物の写真だけにclass behindを追加
     });
 
   // ALLボタンをクリックしたら発動
-  $('.button.all').click(function() {
+  $('.navbar-item.all').click(function() {
     $(".item").removeClass('behind');//全部の画像からclass　behindを削除してから全表示
   });
 });
+
+$(document).ready(function() {
+
+    // Check for click events on the navbar burger icon
+   $(".navbar-burger").click(function() {
+
+        // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
+       $(".navbar-burger").toggleClass("is-active");
+       $(".navbar-menu").toggleClass("is-active");
+
+    });
+ });
 </script>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -7,15 +7,14 @@
 <img src="musubun.png" class="musubun">
 </div>
 
-<%= link_to "All", root_path, class: 'button is-rounded is-large' %>
-<%= link_to "View", "/view", class: 'button is-rounded is-large' %>
-<%= link_to "Food", "/food", class: 'button is-rounded is-large' %>
-
+<button class="button all  is-link is-outlined">ALL</button>
+<button class="button food is-success is-outlined">食べ物</button>
+<button class="button view is-danger is-outlined">景色</button>
 
 <%= form_with(url: map_path, local: true) do |f| %>
 <div class="container">
     <% @images.each do |image| %>
-        <div class="item column is-half is-one-quarter-desktop">
+        <div class="item column is-half is-one-quarter-desktop", id= <%= "#{image.category}" %> >
             <%= image_tag("/#{image.image_path}",:class => "thumbnail")%>
             <%= check_box_tag "go_image_name[#{ image.place_name }]", image.place_name , false ,class:'disabled_checkbox'%>
         </div><br>
@@ -69,4 +68,23 @@ $(document).on('turbolinks:load', function() {
   });
 });
 
+$(function() {
+ 
+  // 食べ物ボタンをクリックしたら発動
+  $('.button.food').click(function() {
+    $(".item").removeClass('behind') //全部の画像からclass　behindを削除してから
+    $("#view.item").addClass('behind');　//景色の写真だけにclass behindを追加
+  });
+
+  // 景色ボタンをクリックしたら発動
+  $('.button.view').click(function() {
+    $(".item").removeClass('behind')//全部の画像からclass　behindを削除してから
+    $("#food.item").addClass('behind');//食べ物の写真だけにclass behindを追加
+    });
+
+  // ALLボタンをクリックしたら発動
+  $('.button.all').click(function() {
+    $(".item").removeClass('behind');//全部の画像からclass　behindを削除してから全表示
+  });
+});
 </script>


### PR DESCRIPTION
画面遷移しないで、カテゴリーで絞り込みたい写真以外をdispaly:noneで見えないようにした。チェックした状態でカテゴリー分けしてもチェック状態を維持できる。